### PR TITLE
Add a lawful parallel Applicative instance with derivatives

### DIFF
--- a/src/Service.ts
+++ b/src/Service.ts
@@ -11,5 +11,6 @@ export type ResourceOf<S extends Service<any, any, any>> = (
 export const of = RT.of(B.Pointed);
 export const map = RT.map(B.Functor);
 export const ap = RT.ap(B.Apply);
+export const apPar = RT.ap(B.ApplyPar);
 export const chain = RT.chain(B.Chain);
 export const fromReader = RT.fromReader(B.Pointed);


### PR DESCRIPTION
The parallel Apply instance currently included isn't lawful, as demonstrated by the tests added in this PR.

The problem is that when:

- The consumption of one of the `ap`'d Brackets fails; and
- the disposal of that, or the other, Bracket also fails; then

the sequential Apply favours the `E` (Left "error" value) returned from the disposal, but the parallel Apply favours the `E` returned from the consumption. This seems like it might be easy to fix, but it turns out that there doesn't seem to be a way to reliably detect whether it was a Bracket's _consumption_ that failed, or whether it was its _disposal_. Without this knowledge, the parallel Apply implementation can't choose the correct `E` to return.